### PR TITLE
fix: update color drawing

### DIFF
--- a/src/components/organisms/TurtleGraphics.tsx
+++ b/src/components/organisms/TurtleGraphics.tsx
@@ -198,11 +198,10 @@ export const TurtleGraphics = forwardRef<TurtleGraphicsHandle, TurtleGraphicsPro
     const handleAddCharacterButton = (): void => {
       if (!selectedCell) return;
 
-      board.setCellColor(selectedCell.x, selectedCell.y, undefined);
-
       const newCharacter = new Character({
         x: selectedCell.x + ORIGIN_X,
         y: selectedCell.y + ORIGIN_Y,
+        penDown: false,
         path: [`${selectedCell.x},${selectedCell.y}`],
       });
 

--- a/src/components/organisms/TurtleGraphics.tsx
+++ b/src/components/organisms/TurtleGraphics.tsx
@@ -67,6 +67,7 @@ export const TurtleGraphics = forwardRef<TurtleGraphicsHandle, TurtleGraphicsPro
           return prevCharacter;
         })
       );
+      board.updateGrid(updatedCharacter);
       setSelectedCharacter(updatedCharacter);
     };
 
@@ -145,18 +146,8 @@ export const TurtleGraphics = forwardRef<TurtleGraphicsHandle, TurtleGraphicsPro
       }
     };
 
-    const drawCharacterPath = (): void => {
-      if (!selectedCharacter || !selectedCharacter.penDown) return;
-
-      board.updateGrid(selectedCharacter);
-    };
-
     const handleClickCharacterMoveForwardButton = (): void => {
       if (!selectedCharacter) return;
-
-      if (selectedCharacter.canMoveForward()) {
-        drawCharacterPath();
-      }
 
       updateCharacter((character) => {
         character.moveForward();
@@ -165,10 +156,6 @@ export const TurtleGraphics = forwardRef<TurtleGraphicsHandle, TurtleGraphicsPro
 
     const handleClickCharacterMoveBackButton = (): void => {
       if (!selectedCharacter) return;
-
-      if (selectedCharacter.canMoveBack()) {
-        drawCharacterPath();
-      }
 
       updateCharacter((character) => {
         character.moveBack();

--- a/tests/solveProblem.test.ts
+++ b/tests/solveProblem.test.ts
@@ -81,11 +81,20 @@ test('Execute eval (2characters)', () => {
 test('Solve a problem (1character)', () => {
   const problemProgram = `
     const character1 = new Character();
+    character1.moveBack();
     character1.moveForward();
     character1.moveForward();
     character1.moveForward();
     character1.moveForward();
     character1.moveForward();
+    character1.turnLeft();
+    character1.moveForward();
+    character1.turnRight();
+    character1.moveBack();
+    character1.upPen();
+    character1.moveBack();
+    character1.moveBack();
+    character1.putPen();
   `;
 
   const answer = solveProblem(problemProgram);
@@ -102,16 +111,16 @@ test('Solve a problem (1character)', () => {
   expect(answer.board.grid).toEqual([
     [{ color: 'red' }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
     [{ color: 'red' }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
+    [{ color: 'red' }, { color: 'red' }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
     [{ color: 'red' }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
-    [{ color: 'red' }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
-    [{ color: 'red' }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
-    [{ color: 'red' }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
+    [{ color: 'red' }, { color: 'red' }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
+    [{ color: 'red' }, { color: "red" }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
     [{ color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
     [{ color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
   ]);
   expect(answer.histories?.at(-1)?.characters?.length).toEqual(1);
-  expect(answer.histories?.at(-1)?.characters?.[0]?.x).toEqual(1);
-  expect(answer.histories?.at(-1)?.characters?.[0]?.y).toEqual(6);
+  expect(answer.histories?.at(-1)?.characters?.[0]?.x).toEqual(2);
+  expect(answer.histories?.at(-1)?.characters?.[0]?.y).toEqual(3);
 });
 
 test('Solve a problem (2characters)', () => {

--- a/tests/solveProblem.test.ts
+++ b/tests/solveProblem.test.ts
@@ -123,7 +123,7 @@ test('Solve a problem (1character)', () => {
   expect(answer.histories?.at(-1)?.characters?.[0]?.y).toEqual(3);
 });
 
-test('Solve a problem (2characters)', () => {
+test('Solve a problem (multiple characters)', () => {
   const problemProgram = `
     const character1 = new Character();
     const character2 = new Character({color: 'green', x: 2, y: 1});
@@ -131,13 +131,14 @@ test('Solve a problem (2characters)', () => {
     character1.moveForward();
     character2.moveForward();
     character2.moveForward();
+    const character3 = new Character({color: 'yellow', penDown: false, x: 3, y: 1});
   `;
 
   const answer = solveProblem(problemProgram);
 
   expect(answer).not.toBeFalsy();
   expect(answer.characters).not.toBeFalsy();
-  expect(answer.characters?.length).toEqual(2);
+  expect(answer.characters?.length).toEqual(3);
   expect(answer.board).not.toBeFalsy();
   expect(answer.characters?.[0].color).toEqual('red');
   expect(answer.characters?.[0].direction).toEqual('down');
@@ -157,7 +158,7 @@ test('Solve a problem (2characters)', () => {
     [{ color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
     [{ color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }, { color: undefined }],
   ]);
-  expect(answer.histories?.at(-1)?.characters?.length).toEqual(2);
+  expect(answer.histories?.at(-1)?.characters?.length).toEqual(3);
   expect(answer.histories?.at(-1)?.characters?.[0]?.x).toEqual(1);
   expect(answer.histories?.at(-1)?.characters?.[0]?.y).toEqual(3);
   expect(answer.histories?.at(-1)?.characters?.[1]?.x).toEqual(2);


### PR DESCRIPTION
Close #17

セルの色を塗る動作の仕様を以下にしました。

- new Character()
    - penDown: falseの場合: 塗らない
    - penDown: trueの場合: キャラクターが生まれたセルを塗る
- moveForward() or moveBack()
    - penDown: falseの場合: 塗らない
    - penDown: trueの場合: 移動先のセルを塗る
- setColor()
    - penDown: falseの場合: 塗らない
    - penDown: trueの場合: キャラクターのいるセルを塗る
- upPen()
    - 塗らない
- putPen()
    - キャラクターがいるセルを塗る

## Self Check

- [x] I've confirmed `All checks have passed` on PR page. (You may leave this box unchecked due to long workflows.)
  - PR title follows [Angular's commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
    - PR title doesn't have `WIP:`.
  - All tests are passed.
    - Test command (e.g., `yarn test`) is passed.
    - Lint command (e.g., `yarn lint`) is passed.
- [x] I've reviewed my changes on PR's diff view.

<!-- Please add screenshots if you modify the UI.
| Current                  | In coming                |
| ------------------------ | ------------------------ |
| <img src="" width="400"> | <img src="" width="400"> |
-->
