### PR TITLE
fix: Fix checkpoint regrex

### DIFF
--- a/src/problems/problemData.ts
+++ b/src/problems/problemData.ts
@@ -85,7 +85,7 @@ export function getProgramCheckpoints(programId: ProgramId): number[] {
 
   const checkpoints: number[] = [];
   for (const [i, line] of lines.entries()) {
-    if (/(\/\/|#)\s*CP\s*$/.test(line)) {
+    if (/(\/\/|#)\s*CP\s*(?:$|\s)/.test(line)) {
       checkpoints.push(i + 1);
     }
   }
@@ -219,8 +219,8 @@ s.get('t').forward(); // CP
 s.get('t').forward();
 s.get('t').rotateRight();
 s.get('t').forward(); //  CP
-s.get('t').forward(); // CP character at end: NG
-s.get('t').forward();
+s.get('t').forward(); // CP character at end: OK
+s.get('t').forward(); // SID
 s.get('t').forward();
 `.trim(),
     js: `

--- a/tests/problemData.test.ts
+++ b/tests/problemData.test.ts
@@ -18,7 +18,7 @@ test.each([
 test.each([
   {
     programId: 'getProgramCheckpointsTest',
-    expected: [2, 5],
+    expected: [2, 5, 6],
   },
 ] as const)('Get program checkpoint line numbers', ({ expected, programId }) => {
   expect(getProgramCheckpoints(programId)).toEqual(expected);


### PR DESCRIPTION
チェックポイントを取得するための正規表現を変更し、行末に文字が含まれていても取得できるようにしました。

## Self Check

- [x] I've confirmed `All checks have passed` on PR page. (You may leave this box unchecked due to long workflows.)
  - PR title follows [Angular's commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
    - PR title doesn't have `WIP:`.
  - All tests are passed.
    - Test command (e.g., `yarn test`) is passed.
    - Lint command (e.g., `yarn lint`) is passed.
- [x] I've reviewed my changes on PR's diff view.

<!-- Please add screenshots if you modify the UI.
| Current                  | In coming                |
| ------------------------ | ------------------------ |
| <img src="" width="400"> | <img src="" width="400"> |
-->
