### PR TITLE
fix: マスの選択を設置済みのタートルと誤解されないようにする

### DIFF
--- a/src/app/(withAuth)/courses/[courseId]/[languageId]/[programId]/BoardEditor.tsx
+++ b/src/app/(withAuth)/courses/[courseId]/[languageId]/[programId]/BoardEditor.tsx
@@ -267,7 +267,7 @@ export const BoardEditor = forwardRef<TurtleGraphicsHandle, TurtleGraphicsProps>
                   <div>y = {selectedPosition.y}</div>
                 </>
               ) : (
-                <div>なし</div>
+                <Box color="gray.600">なし</Box>
               )}
             </HStack>
           </VStack>
@@ -331,12 +331,13 @@ export const BoardEditor = forwardRef<TurtleGraphicsHandle, TurtleGraphicsProps>
                   </Button>
                 </HStack>
               </>
-            ) : selectedPosition ? (
+            ) : (
+              <Box color="gray.600">なし</Box>
+            )}
+            {!selectedCharacter && selectedPosition && (
               <Button colorScheme="brand" size="sm" variant="outline" onClick={() => void handleAddCharacterButton()}>
                 タートルを追加
               </Button>
-            ) : (
-              <div>なし</div>
             )}
           </VStack>
 

--- a/src/app/(withAuth)/courses/[courseId]/[languageId]/[programId]/BoardViewer.tsx
+++ b/src/app/(withAuth)/courses/[courseId]/[languageId]/[programId]/BoardViewer.tsx
@@ -10,7 +10,7 @@ import {
   TURTLE_GRAPHICS_BOARD_GAP_PX as GAP_PX,
   TURTLE_GRAPHICS_BOARD_PADDING_PX as PADDING_PX,
 } from '../../../../../../constants';
-import { Box, Grid, GridItem, Img } from '../../../../../../infrastructures/useClient/chakra';
+import { Box, Grid, GridItem, Img, keyframes } from '../../../../../../infrastructures/useClient/chakra';
 import { charToColor } from '../../../../../../problems/traceProgram';
 import type { CharacterTrace, TraceItemVar } from '../../../../../../problems/traceProgram';
 
@@ -40,6 +40,15 @@ const DIR_TO_TRANSFORM_FUNCTION = {
   W: 'rotate(90deg)',
   E: 'rotate(270deg)',
 } as const;
+
+const focusRingKeyframes = keyframes({
+  '0%': {
+    borderColor: '#d69e2e' /* yellow.500 */,
+  },
+  '100%': {
+    borderColor: '#f6e05e' /* yellow.300 */,
+  },
+});
 
 type Props = BoxProps & {
   board: string | undefined;
@@ -147,8 +156,8 @@ export const BoardViewer: React.FC<Props> = ({
 
       {focusedCell && (
         <Box
-          borderColor="yellow.500"
           borderWidth="4px"
+          css={{ animation: `${focusRingKeyframes} 0.5s linear infinite alternate both` }}
           h={`${CELL_SIZE_PX + 12}px`}
           left={`${PADDING_PX}px`}
           pointerEvents="none"

--- a/src/infrastructures/useClient/chakra.ts
+++ b/src/infrastructures/useClient/chakra.ts
@@ -62,6 +62,7 @@ export {
   InputGroup,
   InputLeftElement,
   InputRightElement,
+  keyframes,
   Link,
   LinkBox,
   LinkOverlay,


### PR DESCRIPTION
close #124 

2つの対策を試みました。1つ目がメインであり、2つ目の効果は補助的だと考えています。

- 選択したマスにタートルが無ければ「選択したタートル」の「なし」表示を残す。
  - マスを未選択のときには、変更前・後ともに「なし」と表示される。
  - 変更前はマスを選択すると「なし」を除去しボタンだけを表示していた。（スクリーンショットを参照）
- フォーカスリングを明滅させる。
  - タートルのような実体のあるオブジェクトでなく、エフェクトの類であることを表現している。

## Self Check

- [x] I've confirmed `All checks have passed` on PR page. (You may leave this box unchecked due to long workflows.)
  - PR title follows [Angular's commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
    - PR title doesn't have `WIP:`.
  - All tests are passed.
    - Test command (e.g., `yarn test`) is passed.
    - Lint command (e.g., `yarn lint`) is passed.
- [x] I've reviewed my changes on PR's diff view.

| Current                  | In coming                |
| ------------------------ | ------------------------ |
| <img src="https://github.com/user-attachments/assets/a3649970-6ed2-4524-83c5-79b12e3e67bc" width="400"> | <img src="https://github.com/user-attachments/assets/be0d30b6-5423-40b3-8298-0419d3960eab" width="400"> |
